### PR TITLE
Accept buffer as first argument in hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ imghash
   .then((hash) => {
     console.log(hash); // 'f884c4d8d1193c07'
   });
-  
+
 // Custom hex length and result in binary
 imghash
   .hash('path/to/file', 4, 'binary')
@@ -58,7 +58,7 @@ Returns: ES6 `Promise`, resolved returns hash string in specified format and len
 
 Parameters:
 
-* `filepath` - path to the image (supported formats are `png` and `jpeg`)
+* `filepath` - path to the image (supported formats are `png` and `jpeg`) or `Buffer`
 * `bits` (optional) - hash length [default: `8`]
 * `format` (optional) - output format [default: `hex`]
 
@@ -93,10 +93,10 @@ Returns: hex string, eg. `1000100010000010`.
 Parameters:
 
 * `s` - hex hash string eg. `f884c4d8d1193c07`
- 
+
 ## Further reading
 
 `imghash` takes advantage of block mean value based hashing method:
 
-* [http://stackoverflow.com/questions/14377854/block-mean-value-hashing-method](http://stackoverflow.com/questions/14377854/block-mean-value-hashing-method)  
+* [http://stackoverflow.com/questions/14377854/block-mean-value-hashing-method](http://stackoverflow.com/questions/14377854/block-mean-value-hashing-method)
 * [http://commonsmachinery.se/2014/09/digital-image-matching-part-1-hashing/](http://commonsmachinery.se/2014/09/digital-image-matching-part-1-hashing/)

--- a/index.js
+++ b/index.js
@@ -14,6 +14,9 @@ function hash(filepath, bits, format) {
   if (bits % 4 !== 0) throw new Error('Invalid bitlength');
 
   return new Promise((resolve, reject) => {
+    if (Buffer.isBuffer(filepath)) {
+      return resolve(filepath);
+    }
 
     fs.readFile(filepath, (err, content) => {
       if (err) return reject(err);


### PR DESCRIPTION
If we got file in HTTP server it is useful to compute hash from Buffer.