### PR TITLE
Depend directly on blockhash-core instead of blockhash

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const fs = require("fs");
-const blockhash = require("blockhash");
+const blockhash = require("blockhash-core");
 const { imageFromBuffer, getImageData } = require("@canvas/image");
 
 function hash(filepath, bits, format) {
@@ -30,7 +30,7 @@ function hash(filepath, bits, format) {
 }
 
 function hashRaw(data, bits) {
-  return blockhash.blockhashData(data, bits, 2);
+  return blockhash.bmvbhash(data, bits);
 }
 
 function hexToBinary(s) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "imghash",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -851,10 +851,10 @@
         "tweetnacl": "^0.14.3"
       }
     },
-    "blockhash": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/blockhash/-/blockhash-0.2.0.tgz",
-      "integrity": "sha1-fJea5QF/0lLoGfvnYbCWcDlCzPc="
+    "blockhash-core": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/blockhash-core/-/blockhash-core-0.1.0.tgz",
+      "integrity": "sha512-Cv7BgBo0jjVPaeuel4cvxf9LqIGsYNIPz9DAGvvrF9LRlEq9Q3HXu+S8bklPCae0sCxAXic4HGMoImf3FeO3Nw=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -3214,11 +3214,6 @@
         }
       }
     },
-    "jpeg-js": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.3.6.tgz",
-      "integrity": "sha512-MUj2XlMB8kpe+8DJUGH/3UJm4XpI8XEgZQ+CiHDeyrGoKPdW/8FJv6ku+3UiYm5Fz3CWaL+iXmD8Q4Ap6aC1Jw=="
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3867,11 +3862,6 @@
       "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
       "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
       "dev": true
-    },
-    "png-js": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/png-js/-/png-js-0.1.1.tgz",
-      "integrity": "sha1-HMfCEjA6yr50Jj7DrHgAlYAkLZM="
     },
     "posix-character-classes": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -34,8 +34,6 @@
   },
   "dependencies": {
     "@canvas/image": "^1.0.0",
-    "blockhash": "^0.2.0",
-    "jpeg-js": "^0.3.6",
-    "png-js": "^0.1.1"
+    "blockhash-core": "^0.1.0"
   }
 }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -37,7 +37,7 @@ it('should create close hashes similar images', async () => {
   const h2 = await imghash.hash(__dirname + '/files/absolut1');
   const dist = leven(h1, h2);
   expect(dist).not.toBe(0);
-  expect(dist).toBeLessThan(12);
+  expect(dist).toBeLessThan(14);
 });
 
 it('should support binary output', async () => {
@@ -55,7 +55,7 @@ it('should support binary output', async () => {
  */
 it('should hash palette based pngs correctly', async () => {
   const h1 = await imghash.hash(__dirname + '/files/Arius.png', 16, 'hex');
-  const h2 = '0ff91ff10ff1000300018fd984d79ddf8e058fc30fc30fc3dfc3c3c303831783';
+  const h2 = '0ff91ff10ff1008300018fd986d79ddf9e058fc30fc30fc3dfc3c3c30b831783';
   expect(h1).toBe(h2);
 });
 


### PR DESCRIPTION
The test cases are changed because this now incorporates this bugfix: https://github.com/commonsmachinery/blockhash-js/commit/24409f0dccc4a3f8b9b9ea266a7f726d7a44def2

~~I'm not sure if this means that we should publish this as a breaking version, since some of the hashes previously produced will be changed. I think that this would be best.~~ Since we are at a `0.0.x` this doesn't actually matter 😄 